### PR TITLE
Command to delete birthday

### DIFF
--- a/src/database_util.py
+++ b/src/database_util.py
@@ -96,6 +96,20 @@ def delete(person):
         return False
 
 
+def delete_all(guild_id):
+    connection = connect()
+    if connection is not None:
+        query = f'DELETE FROM {TABLE_NAME_DATA} ' \
+                f'WHERE {COLUMN_GUILD_ID} = %s;'
+        cursor = connection.cursor()
+        cursor.execute(query, (guild_id,))
+        connection.commit()
+        disconnect(connection)
+        return True
+    else:
+        return False
+
+
 def get_birthday_children():
     """Getting all birthday children from the database and calculates their age."""
     connection = connect()

--- a/src/database_util.py
+++ b/src/database_util.py
@@ -80,6 +80,22 @@ def insert(person):
         return False
 
 
+def delete(person):
+    """Deletes a person and its birthday. Returns True when successfully saved, False otherwise."""
+    connection = connect()
+    if connection is not None:
+        query = f'DELETE FROM {TABLE_NAME_DATA} ' \
+                f'WHERE {COLUMN_PERSON_ID} = %s ' \
+                f'AND {COLUMN_GUILD_ID} = %s;'
+        cursor = connection.cursor()
+        cursor.execute(query, (person.person_id, person.guild_id))
+        connection.commit()
+        disconnect(connection)
+        return True
+    else:
+        return False
+
+
 def get_birthday_children():
     """Getting all birthday children from the database and calculates their age."""
     connection = connect()

--- a/src/main.py
+++ b/src/main.py
@@ -64,6 +64,10 @@ async def on_message(message):
     elif msg_words[0] == 'delete':
         delete_date(message.channel, message.author, message.guild)
 
+    # Delete all (only admin) #
+    elif msg_words[0] == 'delete-all' and is_admin(message.author):
+        delete_all(message.channel, message.guild)
+
     # Set channel to post at #
     elif msg_words[0] == 'set-channel' and is_admin(message.author):
         save_channel(message.guild, message.channel)
@@ -77,6 +81,7 @@ async def on_message(message):
         if is_admin(message.author):
             text += 'Additional admin commands:\n' \
                     '```\n' \
+                    '!bdg delete-all     Deletes all saved birthdays. Cannot be undone!\n' \
                     '!bdg list           Prints a list of all saved birthdays.\n' \
                     '!bdg set-channel    Sets current channel for upcoming congratulations.```'
         await send_message(text, message.channel)

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,10 @@ async def on_message(message):
     elif msg_words[0] == 'set':
         save_date(msg_words[1], message.channel, message.author, message.guild)
 
+    # Delete user's birthday #
+    elif msg_words[0] == 'delete':
+        delete_date(message.channel, message.author, message.guild)
+
     # Set channel to post at #
     elif msg_words[0] == 'set-channel' and is_admin(message.author):
         save_channel(message.guild, message.channel)
@@ -67,7 +71,8 @@ async def on_message(message):
     # Sends a message with a list of all commends #
     elif msg_words[0] == 'help':
         text = '```\n' \
-               '!bdg set <date>     Saves the birthday of the user.\n' \
+               '!bdg delete         Deletes the user\'s birthday.\n' \
+               '!bdg set <date>     Saves the user\'s birthday.\n' \
                '!bdg help           Prints this help message.```\n'
         if is_admin(message.author):
             text += 'Additional admin commands:\n' \
@@ -115,6 +120,21 @@ def save_date(msg, channel, author, guild):
     client.loop.create_task(send_message(f'Save the date! <@{person.person_id}>\'s birthday is at the '
                                          + date_util.parse_to_string(person.birthday)
                                          + '.', channel))
+
+
+def delete_date(channel, author, guild):
+    """Deletes the user's birthday and sends a confirmation message."""
+    person = Person(author.id, None, guild.id)
+    if database_util.delete(person):
+        client.loop.create_task(
+            send_message('<@%s>, I have forgotten your birthday. Do you even have one?' % person.person_id,
+                         channel))
+
+
+def delete_all(channel, guild):
+    """Deletes all birthdays from the current guild."""
+    if database_util.delete_all(guild.id):
+        client.loop.create_task(send_message('I have forgotten all your birthdays. Tell me some!', channel))
 
 
 def save_channel(guild, channel):


### PR DESCRIPTION
Fixes #4 
- Every user should be able to delete its own birthday
- The administrators can delete all birthdays at once if necessary.

To confirm the deletion off all birthdays, the bot is sending a message and waits for a reaction with the thumb up.